### PR TITLE
Fix background-image css on edit/submit/withdraw pages

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -481,7 +481,7 @@ $color-border-light: #DDDDDD;
 
 .preprint-submit-header {
     padding-top: 70px;
-    background: url("img/submit_bg.jpg") no-repeat top center;
+    background: url("img/submit_bg.jpg") top center;
     background-size: cover;
     background-position-y: -50px;
     border-bottom: 1px solid #eee;


### PR DESCRIPTION
## Purpose

To fix the CSS for background images on the withdrawal form.

## Summary of Changes

- Removed `no-repeat` from background-image css

## Side Effects / Testing Notes

Will also fix the background image on the submit/edit page

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
